### PR TITLE
Rational model: incorrect link to numerical method - cap/swaption

### DIFF
--- a/src/main/java/marc/henrard/risq/pricer/capfloor/RationalTwoFactorCapletFloorletPeriodNumericalIntegrationPricer.java
+++ b/src/main/java/marc/henrard/risq/pricer/capfloor/RationalTwoFactorCapletFloorletPeriodNumericalIntegrationPricer.java
@@ -70,7 +70,7 @@ public class RationalTwoFactorCapletFloorletPeriodNumericalIntegrationPricer
     double[] c = FORMULAS.capletCoefficients(caplet, multicurve, model2);
     double pvNum = multicurve.discountFactor(ccy, caplet.getPaymentDate()) /
         multicurve.discountFactor(ccy, caplet.getIborRate().getMaturityDate()) *
-        FORMULAS.pvSemiExplicit(c, expiryTime, model2.a1(), model2.a2(), model2.getCorrelation(), nbSteps);
+        FORMULAS.pvNumericalIntegration(c, expiryTime, model2.a1(), model2.a2(), model2.getCorrelation(), nbSteps);
     return CurrencyAmount.of(ccy, (caplet.getNotional() > 0) ? pvNum : -pvNum);
   }
 

--- a/src/main/java/marc/henrard/risq/pricer/swaption/RationalTwoFactorSwaptionPhysicalProductNumericalIntegrationPricer.java
+++ b/src/main/java/marc/henrard/risq/pricer/swaption/RationalTwoFactorSwaptionPhysicalProductNumericalIntegrationPricer.java
@@ -69,7 +69,7 @@ public class RationalTwoFactorSwaptionPhysicalProductNumericalIntegrationPricer
     ResolvedSwap underlying = swaption.getUnderlying();
     double[] c = FORMULAS.swapCoefficients(underlying, rates, model2);
     double pvNum = FORMULAS
-        .pvSemiExplicit(c, expiryTime, model2.a1(), model2.a2(), model2.getCorrelation(), nbSteps);
+        .pvNumericalIntegration(c, expiryTime, model2.a1(), model2.a2(), model2.getCorrelation(), nbSteps);
     return CurrencyAmount.of(ccy, pvNum * ((swaption.getLongShort() == LongShort.LONG) ? 1.0 : -1.0));
   }
 

--- a/src/main/java/marc/henrard/risq/pricer/swaption/RationalTwoFactorSwaptionPhysicalProductSemiExplicitPricer.java
+++ b/src/main/java/marc/henrard/risq/pricer/swaption/RationalTwoFactorSwaptionPhysicalProductSemiExplicitPricer.java
@@ -65,8 +65,8 @@ public class RationalTwoFactorSwaptionPhysicalProductSemiExplicitPricer
     double expiryTime = model.relativeTime(expiryDateTime);
     ResolvedSwap underlying = swaption.getUnderlying();
     double[] c = FORMULAS_2.swapCoefficients(underlying, rates, model2);
-    double pvNum = 
-        FORMULAS_2.pvSemiExplicit(c, expiryTime, model2.a1(), model2.a2(), model2.getCorrelation(), nbSteps);
+    double pvNum = FORMULAS_2
+        .pvSemiExplicit(c, expiryTime, model2.a1(), model2.a2(), model2.getCorrelation(), nbSteps);
     return CurrencyAmount.of(ccy, (swaption.getLongShort() == LongShort.LONG) ? pvNum : -pvNum);
   }
 


### PR DESCRIPTION
Rational model 2-factor.
Restructuring had replaced numerical integration by semi-explicit computation. Re-established link to the correct numerical method for cap/floor and swaptions.